### PR TITLE
Mark repo as archived

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
 # stub-oidc-broker
 
+>**GOV.UK Verify has closed**
+>
+>This repository is out of date and has been archived
+
 Stub OIDC Broker is a implementation of an OpenID Connect client and an OpenID Provider which uses the Hybrid flow. It makes up part of the Trust Framework prototype together with the following repos -  
 
 * [Trust-Framework-RP](https://github.com/alphagov/stub-trustframework-rp)


### PR DESCRIPTION
Update README.md to mark repo as archived

As agreed in [verify-architecture ADR 0039](https://github.com/alphagov/verify-architecture/blob/master/adr/0039-use-prs-before-archiving-repos.md), a PR must be approved by all engineers on the team before being archived.

Approving this PR indicates approval for this repo to be archived.